### PR TITLE
Let Renovate handle dependencies that Dependabot cannot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,47 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  constraints: {
+    // Must be kept in sync with the major-minor version of Python
+    // being used in the base containers in the Dockerfile.
+    python: "==3.14",
+  },
+
+  customManagers: [
+    {
+      customType: "regex",
+      datasourceTemplate: "pypi",
+      managerFilePatterns: ["Dockerfile"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=pypi\\s+depName=(?<depName>\\S+)\\s*(ENV|ARG)?\\s*.+_VERSION=(?<currentValue>\\S+)",
+      ],
+    },
+    {
+      customType: "regex",
+      datasourceTemplate: "deb",
+      managerFilePatterns: ["Dockerfile"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=deb\\s+depName=(?<depName>\\S+)\\s*(ENV|ARG)?\\s*.+_VERSION=(?<currentValue>\\S+)",
+      ],
+      // The suite here must be kept in sync with the Debian release
+      // used in the base containers in the Dockerfile.
+      //
+      // Note also that the same package version is offered for all
+      // architectures.  In rare cases this is not the case.
+      registryUrlTemplate: "https://deb.debian.org/debian?suite=trixie&components=main,contrib,non-free&binaryArch=amd64",
+    },
+    {
+      customType: "regex",
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "cisagov/mongo-db-from-config",
+      managerFilePatterns: ["/^src/Pipfile$/"],
+      matchStrings: [
+        "cisagov/mongo-db-from-config/archive/(?<currentValue>\\S+).tar.gz",
+      ],
+      versioningTemplate: "semver-coerced", // handles the leading `v`
+    },
+  ],
+  dependencyDashboard: true,
+  enabledManagers: ["custom.regex"],
+  extends: ["config:recommended"],
+  labels: ["dependencies"],
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ ENV CISA_HOME="/home/${CISA_USER}"
 ENV VIRTUAL_ENV="${CISA_HOME}/.venv"
 
 # Versions of the Python packages installed directly
+# renovate: datasource=pypi depName=pip
 ENV PYTHON_PIP_VERSION=26.1.2
+# renovate: datasource=pypi depName=pipenv
 ENV PYTHON_PIPENV_VERSION=2026.6.2
+# renovate: datasource=pypi depName=setuptools
 ENV PYTHON_SETUPTOOLS_VERSION=82.0.1
 
 ###
@@ -81,12 +84,19 @@ RUN groupadd --system --gid ${CISA_GID} ${CISA_GROUP} \
 # We need redis-tools so we can use redis-cli to communicate with
 # redis.  wget is used inside of gather-domains.sh.
 ###
+# renovate: datasource=deb depName=bash
+ENV BASH_VERSION=5.2.37-2+b9
+# renovate: datasource=deb depName=redis-tools
+ENV REDIS_TOOLS_VERSION=5:8.0.2-3+deb13u2
+# renovate: datasource=deb depName=wget
+ENV WGET_VERSION=1.25.0-2
+ENV DEPS="bash=${BASH_VERSION} \
+    redis-tools=${REDIS_TOOLS_VERSION} \
+    wget=${WGET_VERSION}"
 RUN apt update --quiet --quiet \
     && apt install --quiet --quiet --yes \
     --no-install-recommends --no-install-suggests \
-        bash=5.2.37-2+b9 \
-        redis-tools=5:8.0.2-3+deb13u2 \
-        wget=1.25.0-2 \
+    $DEPS \
     && apt --quiet --quiet clean \
     && rm --recursive --force /var/lib/apt/lists/*
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Renovate configuration and some Renovate annotations to allow Renovate to manage some dependencies that Dependabot cannot handle.

## 💭 Motivation and context ##

These dependencies were being updated manually before, so this is an improvement.

## 🧪 Testing ##

I verified that the Renovate config is valid and functions as expected by performing a dry run of Renovate locally.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.